### PR TITLE
Fix assets list in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,11 @@ flutter:
   uses-material-design: true
   assets:
     - assets/words.json
+    - assets/splash_screen.png
+    - assets/icon.png
+    - assets/play_icon.png
+    - assets/help_icon.png
+    - assets/settings_icon.png
     
 flutter_icons:
   android: true


### PR DESCRIPTION
## Summary
- include splash and icon assets in pubspec

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad0953dc08324b0d085462a261c39