### PR TITLE
Improve Android embedding troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,26 @@ Este repositório contém os arquivos iniciais para o projeto **Super Senha**, u
 Consulte o arquivo [`docs/Technical_Documentation.md`](docs/Technical_Documentation.md) para detalhes completos de implementação.
 
 ## Problemas de build no Android
-Se ao compilar surgir a mensagem `Build failed due to use of deleted Android v1 embedding`, verifique se o arquivo `android/app/src/main/kotlin/com/example/supersenha/MainActivity.kt` utiliza `FlutterActivity` (embeddig v2). Esta versão do repositório já está atualizada, mas caso a pasta `android/` tenha sido removida execute `flutter create .` para gerá-la novamente.
+Se ao compilar surgir a mensagem `Build failed due to use of deleted Android v1 embedding`, certifique-se de que o projeto está configurado para o Android v2 embedding. Siga os passos abaixo:
+
+1. Abra `android/app/src/main/AndroidManifest.xml` e verifique se a tag `<application>` contém `android:name="${applicationName}"`.
+2. Dentro da `<activity>` principal (`.MainActivity`), remova qualquer meta‑data do v1 embedding, como:
+
+   ```xml
+   <meta-data
+       android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
+       android:value="true" />
+   ```
+
+3. Ainda na `<activity>` principal, garanta que existe a meta‑data abaixo para habilitar o v2 embedding:
+
+   ```xml
+   <meta-data
+       android:name="flutterEmbedding"
+       android:value="2" />
+   ```
+
+4. Confira se o arquivo `android/app/src/main/kotlin/com/example/supersenha/MainActivity.kt` estende `io.flutter.embedding.android.FlutterActivity`.
+5. Após ajustar os arquivos, execute `flutter clean` e `flutter pub get` para reconstruir o projeto.
+
+Esta versão do repositório já está configurada para o v2 embedding, mas caso a pasta `android/` tenha sido removida execute `flutter create .` para gerá-la novamente.


### PR DESCRIPTION
## Summary
- expand the README section describing how to fix the `Build failed due to use of deleted Android v1 embedding` error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad90e06448324a297bda28306244c