### PR TITLE
Add online word of day and persistence

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^0.13.6
+  shared_preferences: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add http and shared_preferences dependencies
- fetch dictionary and word of the day from vini.me
- persist daily game state using shared preferences
- show success and failure dialogs with play-again option
- allow playing with random words after the daily challenge

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b758ae7d48324bb022776e182b27b