### PR TITLE
Update Android NDK and package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Se ao compilar surgir a mensagem `Build failed due to use of deleted Android v1 
        android:value="2" />
    ```
 
-4. Confira se o arquivo `android/app/src/main/kotlin/com/example/supersenha/MainActivity.kt` estende `io.flutter.embedding.android.FlutterActivity`.
+4. Confira se o arquivo `android/app/src/main/kotlin/me/vini/super_senha/MainActivity.kt` estende `io.flutter.embedding.android.FlutterActivity`.
 5. Após ajustar os arquivos, execute `flutter clean` e `flutter pub get` para reconstruir o projeto.
 
 Esta versão do repositório já está configurada para o v2 embedding, mas caso a pasta `android/` tenha sido removida execute `flutter create .` para gerá-la novamente.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 android {
-    namespace = "com.example.super_senha"
+    namespace = "me.vini.super_senha"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.super_senha"
+        applicationId = "me.vini.super_senha"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/me/vini/super_senha/MainActivity.kt
+++ b/android/app/src/main/kotlin/me/vini/super_senha/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.super_senha
+package me.vini.super_senha
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
## Summary
- bump `ndkVersion` to 27.0.12077973
- change Android package namespace from `com.example.super_senha` to `me.vini.super_senha`
- move MainActivity to new package path
- update README with new path

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b80151d488324899661418ad9e696