### PR TITLE
Add option to use device keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Se ao compilar surgir a mensagem `Build failed due to use of deleted Android v1 
 5. Após ajustar os arquivos, execute `flutter clean` e `flutter pub get` para reconstruir o projeto.
 
 Esta versão do repositório já está configurada para o v2 embedding, mas caso a pasta `android/` tenha sido removida execute `flutter create .` para gerá-la novamente.
+
+## Configurações
+
+No menu de configurações do aplicativo é possível escolher se prefere usar o teclado virtual da aplicação ou o teclado do dispositivo. Por padrão, o teclado do dispositivo é utilizado.


### PR DESCRIPTION
## Summary
- allow choosing device keyboard or in-app keyboard
- hide in-app keyboard when device keyboard is selected
- save keyboard preference in SharedPreferences
- document keyboard selection in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8d8e25688324a0664c7b34bf8e7a