### PR TITLE
Fix failing widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:super_senha/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App loads with Super Senha title', (WidgetTester tester) async {
+    await tester.pumpWidget(const SuperSenhaApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Super Senha'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- update widget test to use `SuperSenhaApp` instead of the template `MyApp`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9bb7a1cc83249fb1f88e87d29b6e