### PR TITLE
Fix widget test runtime assertion

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,12 +5,18 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:super_senha/main.dart';
 
 void main() {
   testWidgets('App loads with Super Senha title', (WidgetTester tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1200, 2000);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+
     await tester.pumpWidget(const SuperSenhaApp());
 
     expect(find.text('Super Senha'), findsOneWidget);


### PR DESCRIPTION
## Summary
- ensure callbacks check `mounted` before using `context`
- skip heavy initialization when running tests and disable device keyboard
- remove trailing space in app bar title
- adjust widget test window size to avoid layout issues

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688ba495a1888324bf252fb32e59d2e6