### PR TITLE
feat: rename app label to Super Senha

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="super_senha"
+        android:label="Super Senha"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
## Summary
- display `Super Senha` as the Android app label

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6892b906fcac8324b3d7f5e7de173f8f