### PR TITLE
feat: cache dictionary and handle offline daily word

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.6
   shared_preferences: ^2.1.0
+  connectivity_plus: ^3.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- cache remote dictionary for offline play
- notify when word of the day unavailable or becomes available

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952423ac0c8324b227c0b953d54b75