### PR TITLE
fix: set namespace for connectivity plugin

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.LibraryExtension
+
 allprojects {
     repositories {
         google()
@@ -14,6 +16,16 @@ subprojects {
 }
 subprojects {
     project.evaluationDependsOn(":app")
+}
+
+subprojects {
+    afterEvaluate {
+        extensions.findByType<LibraryExtension>()?.let { androidExt ->
+            if (name == "connectivity_plus" && androidExt.namespace == null) {
+                androidExt.namespace = "dev.fluttercommunity.plus.connectivity"
+            }
+        }
+    }
 }
 
 tasks.register<Delete>("clean") {


### PR DESCRIPTION
## Summary
- ensure `connectivity_plus` plugin defines a namespace when building with AGP 8

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895440065c48324bc93ea5e491a5e32