### PR TITLE
fix: avoid afterEvaluate error

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,10 +19,10 @@ subprojects {
 }
 
 subprojects {
-    afterEvaluate {
-        extensions.findByType<LibraryExtension>()?.let { androidExt ->
-            if (name == "connectivity_plus" && androidExt.namespace == null) {
-                androidExt.namespace = "dev.fluttercommunity.plus.connectivity"
+    plugins.withId("com.android.library") {
+        extensions.configure<LibraryExtension>("android") {
+            if (name == "connectivity_plus" && namespace == null) {
+                namespace = "dev.fluttercommunity.plus.connectivity"
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace deprecated afterEvaluate block with plugin-based configuration to set connectivity_plus namespace during Android builds

## Testing
- `flutter test`
- `gradle help` *(fails: com.android.builder.sdk.LicenceNotAcceptedException: Failed to install the following Android SDK packages as some licences have not been accepted.)*

------
https://chatgpt.com/codex/tasks/task_e_689545b2a4308324b1d34541594af615